### PR TITLE
fix: evict keys remotely as well

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -325,6 +325,12 @@ func (c *cache) refill(ctx context.Context, cfg *config, keyBytes map[string][]b
 		); err != nil {
 			return nil
 		}
+
+		keys := []string{}
+		for k := range keyBytes {
+			keys = append(keys, k)
+		}
+		c.publishEvictEvents(ctx, keys...)
 	}
 
 	return nil

--- a/cache.go
+++ b/cache.go
@@ -302,6 +302,8 @@ func (c *cache) load(ctx context.Context, cfg *config, keys ...string) ([]Value,
 				WithOnCostAddFunc(c.onLCCostAdd),
 				WithOnCostEvictFunc(c.onLCCostEvict),
 			)
+
+			c.evictRemoteKeyBytes(ctx, m)
 		}
 	}
 
@@ -326,11 +328,7 @@ func (c *cache) refill(ctx context.Context, cfg *config, keyBytes map[string][]b
 			return nil
 		}
 
-		keys := []string{}
-		for k := range keyBytes {
-			keys = append(keys, k)
-		}
-		c.publishEvictEvents(ctx, keys...)
+		c.evictRemoteKeyBytes(ctx, keyBytes)
 	}
 
 	return nil
@@ -352,6 +350,15 @@ func (c *cache) del(ctx context.Context, cfg *config, keys ...string) error {
 	}
 
 	return nil
+}
+
+func (c *cache) evictRemoteKeyBytes(ctx context.Context, keyBytes map[string][]byte) error {
+	keys := []string{}
+	for k := range keyBytes {
+		keys = append(keys, k)
+	}
+
+	return c.publishEvictEvents(ctx, keys...)
 }
 
 func (c *cache) publishEvictEvents(ctx context.Context, keys ...string) error {


### PR DESCRIPTION
# Description

* Evict remote keys when dealing with MSet()