### PR TITLE
feat: support customized package key

### DIFF
--- a/event.go
+++ b/event.go
@@ -41,7 +41,7 @@ func init() {
 
 // Topic generates the topic for specified event.
 func (x eventType) Topic() string {
-	return customKey(topicDelim, packageKey, topicKey, x.String())
+	return getTopic(x.String())
 }
 
 type event struct {

--- a/factory.go
+++ b/factory.go
@@ -17,9 +17,9 @@ var (
 	uuidString = uuid.New().String
 )
 
-func newFactory(sharedCache Adapter, localCache Adapter, options ...ServiceOptions) Factory {
+func newFactory(sharedCache Adapter, localCache Adapter, options ...FactoryOptions) Factory {
 	// load options
-	o := loadServiceOptions(options...)
+	o := loadFactoryOptions(options...)
 	// need to specify marshalFunc and unmarshalFunc at the same time
 	if o.marshalFunc == nil && o.unmarshalFunc != nil {
 		panic(errors.New("both of Marshal and Unmarshal functions need to be specified"))

--- a/factory_test.go
+++ b/factory_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"errors"
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -248,40 +247,4 @@ func (s *factorySuite) TestNewCacheWithOnlyUnmarshal() {
 			UnmarshalFunc:   json.Unmarshal,
 		},
 	})
-}
-
-func (s *factorySuite) TestGetPrefixAndKey() {
-	tests := []struct {
-		Desc     string
-		CacheKey string
-		ExpPfx   string
-		ExpKey   string
-	}{
-		{
-			Desc:     "invalid cache key without delimiter",
-			CacheKey: "12345",
-			ExpPfx:   "12345",
-			ExpKey:   "",
-		},
-		{
-			Desc:     "invalid cache key with only one delimiter",
-			CacheKey: fmt.Sprintf("%s%s%s", "123", cacheDelim, "abc"),
-			ExpPfx:   "abc",
-			ExpKey:   "",
-		},
-		{
-			Desc:     "normal case",
-			CacheKey: getCacheKey("prefix", "key"),
-			ExpPfx:   "prefix",
-			ExpKey:   "key",
-		},
-	}
-
-	for _, t := range tests {
-		pfx, key := getPrefixAndKey(t.CacheKey)
-		s.Require().Equal(t.ExpPfx, pfx, t.Desc)
-		s.Require().Equal(t.ExpKey, key, t.Desc)
-
-		s.TearDownTest()
-	}
 }

--- a/interface.go
+++ b/interface.go
@@ -50,7 +50,7 @@ type Factory interface {
 }
 
 // NewFactory returns the Factory initialized in the main.go.
-func NewFactory(sharedCache Adapter, localCache Adapter, options ...ServiceOptions) Factory {
+func NewFactory(sharedCache Adapter, localCache Adapter, options ...FactoryOptions) Factory {
 	return newFactory(sharedCache, localCache, options...)
 }
 
@@ -109,4 +109,9 @@ type Result interface {
 // duplicated prefix registration panic might occur due to multiple tests.
 func ClearPrefix() {
 	usedPrefixs = map[string]struct{}{}
+}
+
+// Register registers customized parameters in the package.
+func Register(packageKey string) {
+	registerKey(packageKey)
 }

--- a/key_test.go
+++ b/key_test.go
@@ -1,0 +1,107 @@
+package cache
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type keySuite struct {
+	suite.Suite
+}
+
+func (s *keySuite) SetupSuite() {}
+
+func (s *keySuite) TearDownSuite() {}
+
+func (s *keySuite) SetupTest() {}
+
+func (s *keySuite) TearDownTest() {
+	clearRegisteredKey()
+}
+
+func TestKeySuite(t *testing.T) {
+	suite.Run(t, new(keySuite))
+}
+
+func clearRegisteredKey() {
+	regPkgKey = packageKey
+	regKeyOnce = sync.Once{}
+}
+
+func (s *keySuite) TestGetPrefixAndKey() {
+	tests := []struct {
+		Desc     string
+		CacheKey string
+		ExpPfx   string
+		ExpKey   string
+	}{
+		{
+			Desc:     "invalid cache key without delimiter",
+			CacheKey: "12345",
+			ExpPfx:   "12345",
+			ExpKey:   "",
+		},
+		{
+			Desc:     "invalid cache key with only one delimiter",
+			CacheKey: fmt.Sprintf("%s%s%s", "123", cacheDelim, "abc"),
+			ExpPfx:   "abc",
+			ExpKey:   "",
+		},
+		{
+			Desc:     "normal case",
+			CacheKey: getCacheKey("prefix", "key"),
+			ExpPfx:   "prefix",
+			ExpKey:   "key",
+		},
+	}
+
+	for _, t := range tests {
+		pfx, key := getPrefixAndKey(t.CacheKey)
+		s.Require().Equal(t.ExpPfx, pfx, t.Desc)
+		s.Require().Equal(t.ExpKey, key, t.Desc)
+
+		s.TearDownTest()
+	}
+}
+
+func (s *keySuite) TestRegister() {
+	s.Require().Equal(packageKey, regPkgKey)
+
+	Register("specified")
+	s.Require().Equal("specified", regPkgKey)
+
+	Register("another")
+	s.Require().Equal("specified", regPkgKey) // no change
+
+	clearRegisteredKey()
+	s.Require().Equal(packageKey, regPkgKey) // set to default
+
+	Register("another")
+	s.Require().Equal("another", regPkgKey) // set to another
+}
+
+func (s *keySuite) TestRegisterAndGetCacheKey() {
+	var cKey, pfx, key string
+
+	s.Require().Equal(fmt.Sprintf("%s:pfx:key", packageKey), getCacheKey("pfx", "key"))
+
+	Register("my")
+	cKey = getCacheKey("pfx", "key")
+	s.Require().Equal("my:pfx:key", cKey)
+	pfx, key = getPrefixAndKey(cKey)
+	s.Require().Equal(pfx, "pfx")
+	s.Require().Equal(key, "key")
+
+	clearRegisteredKey()
+	s.Require().Equal(fmt.Sprintf("%s:pfx:key", packageKey), getCacheKey("pfx", "key")) // set to default
+
+	Register("") // empty package key
+	cKey = getCacheKey("pfx", "key")
+	s.Require().Equal("pfx:key", cKey)
+	pfx, key = getPrefixAndKey(cKey)
+	s.Require().Equal(pfx, "pfx")
+	s.Require().Equal(key, "key")
+}

--- a/options.go
+++ b/options.go
@@ -8,11 +8,11 @@ type MarshalFunc func(interface{}) ([]byte, error)
 // The default is json.Unmarshal
 type UnmarshalFunc func([]byte, interface{}) error
 
-// ServiceOptions is an alias for functional argument.
-type ServiceOptions func(opts *serviceOptions)
+// FactoryOptions is an alias for functional argument.
+type FactoryOptions func(opts *factoryOptions)
 
-// serviceOptions contains all options which will be applied when calling New().
-type serviceOptions struct {
+// factoryOptions contains all options which will be applied when calling NewFactory().
+type factoryOptions struct {
 	marshalFunc   MarshalFunc
 	unmarshalFunc UnmarshalFunc
 	onCacheHit    func(prefix string, key string, count int)
@@ -24,57 +24,57 @@ type serviceOptions struct {
 
 // WithMarshalFunc sets up the specified marshal function.
 // Needs to consider with unmarshal function at the same time.
-func WithMarshalFunc(f MarshalFunc) ServiceOptions {
-	return func(opts *serviceOptions) {
+func WithMarshalFunc(f MarshalFunc) FactoryOptions {
+	return func(opts *factoryOptions) {
 		opts.marshalFunc = f
 	}
 }
 
 // WithUnmarshalFunc sets up the specified unmarshal function.
 // Needs to consider with marshal function at the same time.
-func WithUnmarshalFunc(f UnmarshalFunc) ServiceOptions {
-	return func(opts *serviceOptions) {
+func WithUnmarshalFunc(f UnmarshalFunc) FactoryOptions {
+	return func(opts *factoryOptions) {
 		opts.unmarshalFunc = f
 	}
 }
 
 // WithPubSub is used to evict keys in local cache
-func WithPubSub(pb Pubsub) ServiceOptions {
-	return func(opts *serviceOptions) {
+func WithPubSub(pb Pubsub) FactoryOptions {
+	return func(opts *factoryOptions) {
 		opts.pubsub = pb
 	}
 }
 
 // OnCacheHitFunc sets up the callback function on cache hitted
-func OnCacheHitFunc(f func(prefix string, key string, count int)) ServiceOptions {
-	return func(opts *serviceOptions) {
+func OnCacheHitFunc(f func(prefix string, key string, count int)) FactoryOptions {
+	return func(opts *factoryOptions) {
 		opts.onCacheHit = f
 	}
 }
 
 // OnCacheMissFunc sets up the callback function on cache missed
-func OnCacheMissFunc(f func(prefix string, key string, count int)) ServiceOptions {
-	return func(opts *serviceOptions) {
+func OnCacheMissFunc(f func(prefix string, key string, count int)) FactoryOptions {
+	return func(opts *factoryOptions) {
 		opts.onCacheMiss = f
 	}
 }
 
 // OnLocalCacheCostAddFunc sets up the callback function on adding the cost of key in local cache
-func OnLocalCacheCostAddFunc(f func(prefix string, key string, cost int)) ServiceOptions {
-	return func(opts *serviceOptions) {
+func OnLocalCacheCostAddFunc(f func(prefix string, key string, cost int)) FactoryOptions {
+	return func(opts *factoryOptions) {
 		opts.onLCCostAdd = f
 	}
 }
 
 // OnLocalCacheCostEvictFunc sets up the callback function on evicting the cost of key in local cache
-func OnLocalCacheCostEvictFunc(f func(prefix string, key string, cost int)) ServiceOptions {
-	return func(opts *serviceOptions) {
+func OnLocalCacheCostEvictFunc(f func(prefix string, key string, cost int)) FactoryOptions {
+	return func(opts *factoryOptions) {
 		opts.onLCCostEvict = f
 	}
 }
 
-func loadServiceOptions(options ...ServiceOptions) *serviceOptions {
-	opts := &serviceOptions{}
+func loadFactoryOptions(options ...FactoryOptions) *factoryOptions {
+	opts := &factoryOptions{}
 	for _, option := range options {
 		option(opts)
 	}


### PR DESCRIPTION
- support registering customized `package key` which is the prefix of cache key. You can empty it as well.
- refactor naming in options